### PR TITLE
dusknoir crest and easy add and remove

### DIFF
--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -938,7 +938,6 @@ function getEndOfTurn(
     texts.push((modifier > 1 ? 'reduced ' : '') + 'burn damage');
   } else if (
     (defender.hasStatus('slp') || defender.hasAbility('Comatose')) &&
-    (attacker.hasAbility('Bad Dreams') || field.chromaticField === 'Haunted-Graveyard') && // Haunted Graveyard - Bad Dreams is always active
     !defenderMagicGuard
   ) {
     damage -= Math.floor(defender.maxHP() / 8);

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1049,8 +1049,7 @@ export function calculateSMSSSV(
   }
 
   if (field.chromaticField === 'Forgotten-Battlefield') {
-    if ((move.named('Poltergeist') && (!defender.item || isQPActive(defender, field))) || // Forgotten Battlefield - Poltergeist never fails
-        (move.named('Gigaton Hammer') && defender.hasType('Steel'))) { // Forgotten Battlefield - Gigaton Hammer deals neutral damage to steel types
+    if ((move.named('Gigaton Hammer') && defender.hasType('Steel'))) { // Forgotten Battlefield - Gigaton Hammer deals double damage to steel and fighting types
       desc.chromaticField = field.chromaticField;
     }
   }
@@ -2480,9 +2479,9 @@ export function calculateAttackSMSSSV(
     attack += Math.floor((Math.floor(attacker.stats['spd'] * 6 / 5) / 10));
   }
 
-  // Dusknoir Crest - Increases physical attack by 25%
+  // Dusknoir Crest - Increases physical attack by 50%
   if (attacker.named('Dusknoir-Crest') && move.category === 'Physical') {
-    attack = pokeRound((attack * 5) / 4);
+    attack = pokeRound((attack * 3) / 2);
   }
 
   // Hypno Crest - Increases special attack by 50%
@@ -2747,9 +2746,9 @@ export function calculateAtModsSMSSSV(
 
   // Fields - Attack Modifiers
 
-  // Haunted Graveyard - Dazzling Gleam, Draining Kiss, Foul Play, and Spirit Break deal 1.2x damage
-  if (field.chromaticField === 'Haunted-Graveyard' && move.named('Dazzling Gleam', 'Draining Kiss', 'Foul Play', 'Spirit Break')) {
-    atMods.push(4915);
+  // Forgotten Battlefield - Gigaton Hammer deals neutral Double damage to Fighting and steel types
+  if (field.chromaticField === 'Forgotten Battlefield' && move.named('Gigaton Hammer') && (defender.hasType('Steel') || defender.hasType('Fighting'))) {
+    atMods.push(8192);
     desc.chromaticField = field.chromaticField;
   }
 

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -2746,7 +2746,7 @@ export function calculateAtModsSMSSSV(
 
   // Fields - Attack Modifiers
 
-  // Forgotten Battlefield - Gigaton Hammer deals neutral Double damage to Fighting and steel types
+  // Forgotten Battlefield - Gigaton Hammer deals double damage to Fighting and Steel types
   if (field.chromaticField === 'Forgotten Battlefield' && move.named('Gigaton Hammer') && (defender.hasType('Steel') || defender.hasType('Fighting'))) {
     atMods.push(8192);
     desc.chromaticField = field.chromaticField;

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1049,7 +1049,7 @@ export function calculateSMSSSV(
   }
 
   if (field.chromaticField === 'Forgotten-Battlefield') {
-    if ((move.named('Gigaton Hammer') && defender.hasType('Steel'))) { // Forgotten Battlefield - Gigaton Hammer deals double damage to steel and fighting types
+    if (move.named('Gigaton Hammer') && defender.hasType('Steel')) { // Forgotten Battlefield - Gigaton Hammer deals double damage to steel and fighting types
       desc.chromaticField = field.chromaticField;
     }
   }

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -251,9 +251,6 @@ export function getMoveEffectiveness(
     }
 
     return effectiveness;
-  // Forgotten Battlefield - Gigaton Hammer deals neutral damage to steel types
-  } else if (field.chromaticField === 'Forgotten-Battlefield' && move.named('Gigaton Hammer') && type === 'Steel') {
-    return 1;
   } else {
     let effectiveness = gen.types.get(toID(move.type))!.effectiveness[type]!;
     if (effectiveness === 0 && (isRingTarget || (field.defenderSide.isIngrain && move.hasType('Ground')))) {


### PR DESCRIPTION
dusknoir crest dmg buffed to 50%
Forgotten Battlefield - Gigaton hammer made deal double damage to fighting and steel types
Forgotten Battlefield - removed Poltergeist never fails
Haunted Graveyard - removing bad dreams is always active
Haunted Graveyard - removed Dazzling Gleam, Draining Kiss, Foul Play, and Spirit Break now apply doom deal 1.2x damage along with Astonish, Scary Face, Shadow Claw

The overlord effects intimidate me but I think I can do retaliate? I am going to pick at this every day. Ideally, one change a day and a pull request every week till it is done